### PR TITLE
Add `Ec2#ec2_roles` method that takes multiple roles

### DIFF
--- a/lib/cap-ec2/capistrano.rb
+++ b/lib/cap-ec2/capistrano.rb
@@ -18,6 +18,12 @@ module Capistrano
         @ec2_handler ||= CapEC2::EC2Handler.new
       end
 
+      def ec2_roles(names, options={})
+        names.each do |name|
+          ec2_role(name, options)
+        end
+      end
+
       def ec2_role(name, options={})
         ec2_handler.get_servers_for_role(name).each do |server|
           env.role(name, CapEC2::Utils.contact_point(server),


### PR DESCRIPTION
Defining multiple roles with the same options is quite repetitive at this moment
in time.

```
ec2_role :web, user: user_name
ec2_role :app, user: user_name
ec2_role :db, user: user_name
```

This commit adds `Ec2#ec2_roles` that takes an array of `names` & `options` and
calls `Ec2#ec2_role` for each `name`.

```
ec2_roles [:web, :db, :app], user: user_name
```